### PR TITLE
Change to use Random's default seed of currentTimeMillis()

### DIFF
--- a/src/com/koletar/jj/mineresetlite/Mine.java
+++ b/src/com/koletar/jj/mineresetlite/Mine.java
@@ -186,7 +186,7 @@ public class Mine implements ConfigurationSerializable {
             }
         }
         //Actually reset
-        Random rand = new Random(world.getTime());
+        Random rand = new Random();
         for (int x = minX; x <= maxX; ++x) {
             for (int y = minY; y <= maxY; ++y) {
                 for (int z = minZ; z <= maxZ; ++z) {


### PR DESCRIPTION
world.getTime is limited to the ticks in a minecraft day, and thus is very limited for a seed for a random number generator.

An example of an issue this causes is if you set a mine to reset every 20 minutes (one minecraft day) Random will always be seeded with the same value, and thus always produce the same reset mine. (non-fill mode)
