### PR TITLE
Broadcast updates only to players nearby mine

### DIFF
--- a/src/com/koletar/jj/mineresetlite/Config.java
+++ b/src/com/koletar/jj/mineresetlite/Config.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 public class Config {
     private Config() {}
     private static boolean broadcastInWorldOnly = false;
+    private static boolean broadcastNearbyOnly = false;
     private static boolean checkForUpdates = true;
     private static String locale = "en";
 
@@ -20,8 +21,16 @@ public class Config {
         return broadcastInWorldOnly;
     }
 
+    public static boolean getBroadcastNearbyOnly() {
+        return broadcastNearbyOnly;
+    }
+
     private static void setBroadcastInWorldOnly(boolean broadcastInWorldOnly) {
         Config.broadcastInWorldOnly = broadcastInWorldOnly;
+    }
+
+    private static void setBroadcastNearbyOnly(boolean broadcastNearbyOnly) {
+        Config.broadcastNearbyOnly = broadcastNearbyOnly;
     }
 
     public static void writeBroadcastInWorldOnly(BufferedWriter out) throws IOException {
@@ -30,6 +39,15 @@ public class Config {
         out.write("# reset notifications, and automatic reset warnings, set this to true.");
         out.newLine();
         out.write("broadcast-in-world-only: false");
+        out.newLine();
+    }
+
+    public static void writeBroadcastNearbyOnly(BufferedWriter out) throws IOException {
+        out.write("# If you only want players nearby the mines to recieive reset notifications,");
+        out.newLine();
+        out.write("# and automatic reset warnings, set this to true.");
+        out.newLine();
+        out.write("broadcast-nearby-only: false");
         out.newLine();
     }
 
@@ -92,6 +110,11 @@ public class Config {
             Config.setBroadcastInWorldOnly(config.getBoolean("broadcast-in-world-only"));
         } else {
             Config.writeBroadcastInWorldOnly(out);
+        }
+        if (config.contains("broadcast-nearby-only")) {
+            Config.setBroadcastNearbyOnly(config.getBoolean("broadcast-nearby-only"));
+        } else {
+            Config.writeBroadcastNearbyOnly(out);
         }
         if (config.contains("check-for-updates")) {
             Config.setCheckForUpdates(config.getBoolean("check-for-updates"));

--- a/src/com/koletar/jj/mineresetlite/Mine.java
+++ b/src/com/koletar/jj/mineresetlite/Mine.java
@@ -206,15 +206,20 @@ public class Mine implements ConfigurationSerializable {
         this.isSilent = isSilent;
     }
 
+    public boolean isInside(Player p) {
+        Location l = p.getLocation();
+        return (l.getX() >= minX && l.getX() <= maxX)
+            && (l.getY() >= minY && l.getY() <= maxY)
+            && (l.getZ() >= minZ && l.getZ() <= maxZ);
+    }
+
     public void reset() {
         //Get probability map
         List<CompositionEntry> probabilityMap = mapComposition(composition);
         //Pull players out
         for (Player p : Bukkit.getServer().getOnlinePlayers()) {
             Location l = p.getLocation();
-            if ((l.getX() >= minX && l.getX() <= maxX)
-                    && (l.getY() >= minY && l.getY() <= maxY)
-                    && (l.getZ() >= minZ && l.getZ() <= maxZ)) {
+            if (isInside(p)) {
                 p.teleport(new Location(world, l.getX(), maxY + 2D, l.getZ()));
             }
         }
@@ -249,16 +254,16 @@ public class Mine implements ConfigurationSerializable {
             resetClock--; //Tick down to the reset
         }
         if (resetClock == 0) {
+            if (!isSilent) {
+                MineResetLite.broadcast(Phrases.phrase("mineAutoResetBroadcast", this), this);
+            }
             reset();
             resetClock = resetDelay;
-            if (!isSilent) {
-                MineResetLite.broadcast(Phrases.phrase("mineAutoResetBroadcast", this), world);
-            }
             return;
         }
         for (Integer warning : resetWarnings) {
             if (warning == resetClock) {
-                MineResetLite.broadcast(Phrases.phrase("mineWarningBroadcast", this, warning), world);
+                MineResetLite.broadcast(Phrases.phrase("mineWarningBroadcast", this, warning), this);
             }
         }
     }

--- a/src/com/koletar/jj/mineresetlite/MineResetLite.java
+++ b/src/com/koletar/jj/mineresetlite/MineResetLite.java
@@ -308,9 +308,16 @@ public class MineResetLite extends JavaPlugin {
         return false; //Fallthrough
     }
 
-    public static void broadcast(String message, World world) {
-        if (Config.getBroadcastInWorldOnly()) {
-            for (Player p : world.getPlayers()) {
+    public static void broadcast(String message, Mine mine) {
+        if (Config.getBroadcastNearbyOnly()) {
+            for (Player p : mine.getWorld().getPlayers()) {
+                if (mine.isInside(p)) {
+                    p.sendMessage(message);
+                }
+            }
+            Bukkit.getLogger().info(message);
+        } else if (Config.getBroadcastInWorldOnly()) {
+            for (Player p : mine.getWorld().getPlayers()) {
                 p.sendMessage(message);
             }
             Bukkit.getLogger().info(message);

--- a/src/com/koletar/jj/mineresetlite/commands/MineCommands.java
+++ b/src/com/koletar/jj/mineresetlite/commands/MineCommands.java
@@ -359,8 +359,8 @@ public class MineCommands {
             //Silent reset
             mines[0].reset();
         } else {
+            MineResetLite.broadcast(phrase("mineResetBroadcast", mines[0], sender), mines[0]);
             mines[0].reset();
-            MineResetLite.broadcast(phrase("mineResetBroadcast", mines[0], sender), mines[0].getWorld());
         }
     }
 


### PR DESCRIPTION
This change adds configuration toggle to only broadcast to players nearby mine.  Currently this only broadcasts to players directly inside the mine, this could potentially be changed to a small radius around the mine as well.
