### PR TITLE
Fix fuzzy detection to prevent misdetected mine names

### DIFF
--- a/src/com/koletar/jj/mineresetlite/MineResetLite.java
+++ b/src/com/koletar/jj/mineresetlite/MineResetLite.java
@@ -223,7 +223,7 @@ public class MineResetLite extends JavaPlugin {
     public Mine[] matchMines(String in) {
         List<Mine> matches = new LinkedList<Mine>();
         for (Mine mine : mines) {
-            if (mine.getName().toLowerCase().contains(in.toLowerCase())) {
+            if (mine.getName().toLowerCase().equals(in.toLowerCase())) {
                 matches.add(mine);
             }
         }


### PR DESCRIPTION
At times when myself or my server administrators are resetting a mine, it will pick up the wrong name for the mine instead of returning a "multiple result" error. We've taken to changing the mine names to completely separate three-digit numbers, but this is confusing to our staff team as we've had to write out a list of these new mine names (in correlation to the real mine names.)

A good way to fix this issue with fuzzy detection is to change

``` java
if (mine.getName().toLowerCase().contains(in.toLowerCase())) {
    matches.add(mine);
}
```

**to**

``` java
if (mine.getName().toLowerCase().equals(in.toLowerCase())) {
    matches.add(mine);
}
```
