### PR TITLE
Fix global reset notifications for Bukkit 1.7.10

### DIFF
--- a/src/com/koletar/jj/mineresetlite/MineResetLite.java
+++ b/src/com/koletar/jj/mineresetlite/MineResetLite.java
@@ -333,7 +333,9 @@ public class MineResetLite extends JavaPlugin {
             }
             Bukkit.getLogger().info(message);
         } else {
-            Bukkit.getServer().broadcastMessage(message);
+            for(Player p : Bukkit.getServer().getOnlinePlayers()){
+                p.sendMessage(message);
+            }
         }
     }
 }


### PR DESCRIPTION
There occurred a bug with the mine reset notifications, where non-OP players were not able to receive mine reset notifications & warnings.